### PR TITLE
Include the ADD command in Dockerfile to load the Process_data.ipynb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,5 @@ RUN pip install Cython --install-option="--no-cython-compile"
 RUN pip install tflearn scikit-image scikit-learn pandas keras
 RUN pip install librosa
 WORKDIR "/notebooks" 
+ADD . /notebooks
 CMD ["/run_jupyter.sh"]


### PR DESCRIPTION
Thanks for the great post and easy intro to some machine learning!

The Dockerfile was an easy way to get environment.  The provided file just puts the default TensorFlow notebooks in place.  

I was able to get your batdectection notebooks live on the image with the ADD command. The ADD command adds the content of the local directory to the docker
image.  This sets up the docker image to explore the batdetector.

Works especially well when the labeled data set is unpacked into the
current directory.

docker build -t batdetection .

This builds a working docker image with the batdection python notebook.